### PR TITLE
Updates Stenographer definition from the last Ginkgo version

### DIFF
--- a/icons.go
+++ b/icons.go
@@ -15,6 +15,7 @@ type SpecsIcons struct {
 	failed  string
 	pending string
 	skipped string
+	panicked string
 }
 
 func newSpecsIcons() SpecsIcons {
@@ -25,6 +26,7 @@ func newSpecsIcons() SpecsIcons {
 			failed:  " ",
 			pending: " ",
 			skipped: " ",
+			panicked: " ",
 		}
 	}
 
@@ -33,5 +35,6 @@ func newSpecsIcons() SpecsIcons {
 		failed:  `✘`,
 		pending: `❗`,
 		skipped: `✱`,
+		panicked: `💀`,
 	}
 }

--- a/stenographer.go
+++ b/stenographer.go
@@ -34,7 +34,12 @@ func (s *Stenographer) AnnounceAggregatedParallelRun(nodes int, quiet bool) {
 }
 
 // AnnounceParallelRun will do nothing.
-func (s *Stenographer) AnnounceParallelRun(node int, nodes int, specsToRun int, totalSpecs int, quiet bool) {
+func (s *Stenographer) AnnounceParallelRun(node int, nodes int, succinct bool) {
+	// Ignore rendering.
+}
+
+// AnnounceTotalNumberOfSpecs will do nothing.
+func (s *Stenographer) AnnounceTotalNumberOfSpecs(total int, succinct bool) {
 	// Ignore rendering.
 }
 
@@ -135,7 +140,7 @@ func (s *Stenographer) AnnounceSpecTimedOut(spec *types.SpecSummary, quiet bool,
 // AnnounceSpecPanicked will print the stack of the spec with its status.
 func (s *Stenographer) AnnounceSpecPanicked(spec *types.SpecSummary, quiet bool, fullTrace bool) {
 	s.renderLines(spec, false, func(space, text string) {
-		renderLineWithContext(space, rbf(Icons.failed), rf(text), rbf("(panic)"))
+		renderLineWithContext(space, rbf(Icons.panicked), rf(text), rbf("(panic)"))
 	})
 }
 


### PR DESCRIPTION
Since the last update on the Macchiato, the Ginkgo has changed a bit the Stenographer interface definition. This pull request fixes that.

Another small update is a new icon for the panicked specs. For a better visual differentiation.