### PR TITLE
Add the fullstack trace on summary of panicked specs

### DIFF
--- a/render.go
+++ b/render.go
@@ -1,11 +1,11 @@
 package macchiato
 
 import (
+	"bufio"
 	"fmt"
 	"strings"
 
 	"github.com/onsi/ginkgo/types"
-	"bufio"
 )
 
 func getSpace(level int) string {
@@ -77,7 +77,7 @@ func renderPanickedSpecContext(space, text string, failure types.SpecFailure) {
 	renderNewLine()
 	scanner := bufio.NewScanner(strings.NewReader(failure.Location.FullStackTrace))
 	for scanner.Scan() {
-		renderText(space, strings.Replace(scanner.Text(), "\t", "    ", 1))
+		renderText(space, strings.Replace(scanner.Text(), "\t", "  ", 1))
 	}
 	renderNewLine()
 	renderTextWithoutSpace(rf(failure.Message))

--- a/render.go
+++ b/render.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/onsi/ginkgo/types"
+	"bufio"
 )
 
 func getSpace(level int) string {
@@ -63,6 +64,21 @@ func renderFailedSpecHeader() {
 func renderFailedSpecContext(space, text string, failure types.SpecFailure) {
 	renderLine(space, rbf(Icons.failed), rf(text))
 	renderText(space, gf(failure.Location.String()))
+	renderNewLine()
+	renderTextWithoutSpace(rf(failure.Message))
+	if failure.ForwardedPanic != "" {
+		renderTextWithoutSpace(rf(failure.ForwardedPanic))
+	}
+	renderNewLine()
+}
+
+func renderPanickedSpecContext(space, text string, failure types.SpecFailure) {
+	renderLine(space, rbf(Icons.panicked), rf(text))
+	renderNewLine()
+	scanner := bufio.NewScanner(strings.NewReader(failure.Location.FullStackTrace))
+	for scanner.Scan() {
+		renderText(space, strings.Replace(scanner.Text(), "\t", "    ", 1))
+	}
 	renderNewLine()
 	renderTextWithoutSpace(rf(failure.Message))
 	if failure.ForwardedPanic != "" {

--- a/stenographer.go
+++ b/stenographer.go
@@ -170,7 +170,11 @@ func (s *Stenographer) SummarizeFailures(summaries []*types.SpecSummary) {
 	renderFailedSpecHeader()
 
 	for _, summary := range failingSpecs {
-		if summary.HasFailureState() {
+		if summary.Panicked() {
+			s.renderLines(summary, false, func(space, text string) {
+				renderPanickedSpecContext(space, text, summary.Failure)
+			})
+		} else if summary.HasFailureState() {
 			s.renderLines(summary, false, func(space, text string) {
 				renderFailedSpecContext(space, text, summary.Failure)
 			})


### PR DESCRIPTION
Panicked specs did not print the full stack trace of the error. This can make life difficult when dealing with a big amount of code (that was my case XD).

This pull request enables Macchiato stenographer to print the full stack trace in case of panicked specs.