### PR TITLE
Adds support for displaying failing test output

### DIFF
--- a/render.go
+++ b/render.go
@@ -121,3 +121,12 @@ func renderSuiteFailure(name string, summary *types.SetupSummary) {
 	renderNewLine()
 	renderFailedSpecContext(getSpace(0), fmt.Sprintf("An error has occurred with %s.", name), summary.Failure)
 }
+
+func renderCaptureOutput(space, output string) {
+	if output != "" {
+		renderNewLine()
+		renderText(space, bf("Test output:"))
+		renderText("", output)
+		renderNewLine()
+	}
+}

--- a/stenographer.go
+++ b/stenographer.go
@@ -173,10 +173,12 @@ func (s *Stenographer) SummarizeFailures(summaries []*types.SpecSummary) {
 		if summary.Panicked() {
 			s.renderLines(summary, false, func(space, text string) {
 				renderPanickedSpecContext(space, text, summary.Failure)
+				renderCaptureOutput(space, summary.CapturedOutput)
 			})
 		} else if summary.HasFailureState() {
 			s.renderLines(summary, false, func(space, text string) {
 				renderFailedSpecContext(space, text, summary.Failure)
+				renderCaptureOutput(space, summary.CapturedOutput)
 			})
 		}
 	}


### PR DESCRIPTION
This pull request enables the Macchiato to print out the captured output when a test fails.